### PR TITLE
Fix exception while extracting package

### DIFF
--- a/install-ancm.ps1
+++ b/install-ancm.ps1
@@ -101,13 +101,15 @@ function Test-ANCMExists()
 }
 
 function Invoke-UpdateANCM ($Version) {
-    $tempFolder = [System.IO.Path]::GetTempFileName()
+    $tempFolderName = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetTempFileName())
+    $tempFolder = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath() ,$tempFolderName)
+    [System.IO.Directory]::CreateDirectory($tempFolder)
     Remove-Item $tempFolder
     $tempFile = [System.IO.Path]::GetTempFileName() |
         Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
-    $nupkgPath = "https://www.nuget.org/packages/Microsoft.AspNetCore.AspNetCoreModule/" + $Version
+    $nupkgPath = "https://www.nuget.org/api/v2/package/Microsoft.AspNetCore.AspNetCoreModule/" + $Version
     Invoke-WebRequest -Uri $nupkgPath -OutFile $tempFile
-    
+    Write-Host "Extracting from '$tempFile' to '$tempFolder'"
     Add-Type -AssemblyName System.IO.Compression.FileSystem
     [System.IO.Compression.ZipFile]::ExtractToDirectory($tempFile, $tempFolder)
     $schemaPath = Join-Path -Path $tempFolder -ChildPath "aspnetcore_schema.xml"


### PR DESCRIPTION
Fixing a few issues here:
1. Call to `ExtractToDirectory` fails with an exception:
```powershell
Exception calling "ExtractToDirectory" with "2" argument(s): "End of Central Directory
record could not be found."
```
as it expects a directory as a second argument and not a file

2.  A call to Nuget was downloading a page instead of the package, changed the URL to point to the package API.